### PR TITLE
Fix jqueryui accordion path dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var React    = require('react');
 var ReactDOM = require('react-dom');
 var $        = require('jquery');
 
-require('jquery-ui/accordion');
+require('jquery-ui/ui/widgets/accordion');
 
 var Accordion = React.createClass({
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jqueryui-accordion",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A simple react component for jquery-ui's accordion",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The path to the jquery ui accordion was not being found when trying to use the React component.
The require statement is now updated to point to the correct path.